### PR TITLE
Exo05

### DIFF
--- a/README ETUDIANTS.md
+++ b/README ETUDIANTS.md
@@ -1,0 +1,5 @@
+pour chaque groupe participants:
+
+NOM prenom 
+ - AUTRET Pierrick
+ - BOLE-RICHARD Nathan

--- a/src/12_RefactoringGolf/exo5/kata.ts
+++ b/src/12_RefactoringGolf/exo5/kata.ts
@@ -38,7 +38,7 @@ if (player == this._lastSymbol) {
 }
 
 private validatePositionIsEmpty(x: number, y: number) {
-if (this._board.TileAt(x, y).Symbol != emptyPlay) { // accès direct à l'attribut privé
+if (!this._board.TileAt(x, y).isEmpty()) {
   throw new Error('Invalid position');
 }
 }
@@ -56,10 +56,28 @@ return this._board.findRowFullWithSamePlayer();
 }
 }
 
-interface Tile {
+class Tile {
 X: number;
 Y: number;
 Symbol: string;
+
+constructor(x: number, y: number, symbol: string) {
+this.X = x;
+this.Y = y;
+this.Symbol = symbol;
+}
+
+isEmpty(): boolean {
+return this.Symbol === emptyPlay;
+}
+
+hasSameSymbolAs(other: Tile): boolean {
+return this.Symbol === other.Symbol;
+}
+
+getSymbol(): string {
+return this.Symbol;
+}
 }
 
 class Board {
@@ -68,7 +86,7 @@ private _plays: Tile[] = [];
 constructor() {
 for (let i = firstRow; i <= thirdRow; i++) {
   for (let j = firstColumn; j <= thirdColumn; j++) {
-    const tile: Tile = { X: i, Y: j, Symbol: emptyPlay };
+    const tile = new Tile(i, j, emptyPlay);
     this._plays.push(tile);
   }
 }
@@ -84,15 +102,15 @@ this._plays.find((t: Tile) => t.X == x && t.Y == y)!.Symbol = symbol;
 
 public findRowFullWithSamePlayer(): string {
 if (this.isRowFull(firstRow) && this.isRowFullWithSameSymbol(firstRow)) {
-  return this.TileAt(firstRow, firstColumn)!.Symbol; // accès direct à l'attribut privé
+  return this.TileAt(firstRow, firstColumn)!.getSymbol();
 }
 
 if (this.isRowFull(secondRow) && this.isRowFullWithSameSymbol(secondRow)) {
-  return this.TileAt(secondRow, firstColumn)!.Symbol; // accès direct à l'attribut privé
+  return this.TileAt(secondRow, firstColumn)!.getSymbol();
 }
 
 if (this.isRowFull(thirdRow) && this.isRowFullWithSameSymbol(thirdRow)) {
-  return this.TileAt(thirdRow, firstColumn)!.Symbol; // accès direct à l'attribut privé
+  return this.TileAt(thirdRow, firstColumn)!.getSymbol();
 }
 
 return emptyPlay;
@@ -100,16 +118,16 @@ return emptyPlay;
 
 private isRowFull(row: number) {
 return (
-    this.TileAt(row, firstColumn)!.Symbol != emptyPlay && // accès/comparaison direct à l'attribut privé
-    this.TileAt(row, secondColumn)!.Symbol != emptyPlay && // accès/comparaison direct à l'attribut privé
-    this.TileAt(row, thirdColumn)!.Symbol != emptyPlay // accès/comparaison direct à l'attribut privé
+    !this.TileAt(row, firstColumn)!.isEmpty() &&
+    !this.TileAt(row, secondColumn)!.isEmpty() &&
+    !this.TileAt(row, thirdColumn)!.isEmpty()
 );
 }
 
 private isRowFullWithSameSymbol(row: number) {
 return (
-    this.TileAt(row, firstColumn)!.Symbol == this.TileAt(row, secondColumn)!.Symbol && // accès/comparaison direct à l'attribut privé
-    this.TileAt(row, thirdColumn)!.Symbol == this.TileAt(row, secondColumn)!.Symbol // accès/comparaison direct à l'attribut privé
+    this.TileAt(row, firstColumn)!.hasSameSymbolAs(this.TileAt(row, secondColumn)!) &&
+    this.TileAt(row, thirdColumn)!.hasSameSymbolAs(this.TileAt(row, secondColumn)!)
 );
 }
 }

--- a/src/12_RefactoringGolf/exo5/kata.ts
+++ b/src/12_RefactoringGolf/exo5/kata.ts
@@ -38,7 +38,7 @@ if (player == this._lastSymbol) {
 }
 
 private validatePositionIsEmpty(x: number, y: number) {
-if (this._board.TileAt(x, y).Symbol != emptyPlay) {
+if (this._board.TileAt(x, y).Symbol != emptyPlay) { // accès direct à l'attribut privé
   throw new Error('Invalid position');
 }
 }
@@ -84,15 +84,15 @@ this._plays.find((t: Tile) => t.X == x && t.Y == y)!.Symbol = symbol;
 
 public findRowFullWithSamePlayer(): string {
 if (this.isRowFull(firstRow) && this.isRowFullWithSameSymbol(firstRow)) {
-  return this.TileAt(firstRow, firstColumn)!.Symbol;
+  return this.TileAt(firstRow, firstColumn)!.Symbol; // accès direct à l'attribut privé
 }
 
 if (this.isRowFull(secondRow) && this.isRowFullWithSameSymbol(secondRow)) {
-  return this.TileAt(secondRow, firstColumn)!.Symbol;
+  return this.TileAt(secondRow, firstColumn)!.Symbol; // accès direct à l'attribut privé
 }
 
 if (this.isRowFull(thirdRow) && this.isRowFullWithSameSymbol(thirdRow)) {
-  return this.TileAt(thirdRow, firstColumn)!.Symbol;
+  return this.TileAt(thirdRow, firstColumn)!.Symbol; // accès direct à l'attribut privé
 }
 
 return emptyPlay;
@@ -100,16 +100,16 @@ return emptyPlay;
 
 private isRowFull(row: number) {
 return (
-    this.TileAt(row, firstColumn)!.Symbol != emptyPlay &&
-    this.TileAt(row, secondColumn)!.Symbol != emptyPlay &&
-    this.TileAt(row, thirdColumn)!.Symbol != emptyPlay
+    this.TileAt(row, firstColumn)!.Symbol != emptyPlay && // accès/comparaison direct à l'attribut privé
+    this.TileAt(row, secondColumn)!.Symbol != emptyPlay && // accès/comparaison direct à l'attribut privé
+    this.TileAt(row, thirdColumn)!.Symbol != emptyPlay // accès/comparaison direct à l'attribut privé
 );
 }
 
 private isRowFullWithSameSymbol(row: number) {
 return (
-    this.TileAt(row, firstColumn)!.Symbol == this.TileAt(row, secondColumn)!.Symbol &&
-    this.TileAt(row, thirdColumn)!.Symbol == this.TileAt(row, secondColumn)!.Symbol
+    this.TileAt(row, firstColumn)!.Symbol == this.TileAt(row, secondColumn)!.Symbol && // accès/comparaison direct à l'attribut privé
+    this.TileAt(row, thirdColumn)!.Symbol == this.TileAt(row, secondColumn)!.Symbol // accès/comparaison direct à l'attribut privé
 );
 }
 }


### PR DESCRIPTION
on a identifier toutes les parties du code ou des actions/comparaisons sur des objets se faisait directement sur leurs attribut et pas a partir de fonction prédéfinis ce qui va a l'encontre de la loi de Demeter.
plus précisement on a corriger les accès a symbole de l'objet Tile au lieu d'utiliser une methode. on a donc corriger l'objet Tile d'interface a class pour que ca soit un vrai objet qui contienne des methodes et on a ajouter les méthodes isEmpty(), hasSameSymbol(other) et getSymbol() et on a refactor les méthode qui pour qu'elle utilisent ces nouvelle méthode